### PR TITLE
Fix missing `evennia.` in setting

### DIFF
--- a/docs/source/Contribs/Contrib-Menu-Login.md
+++ b/docs/source/Contribs/Contrib-Menu-Login.md
@@ -11,7 +11,7 @@ menu system `EvMenu` under the hood.
 To install, add this to `mygame/server/conf/settings.py`:
 
     CMDSET_UNLOGGEDIN = "evennia.contrib.base_systems.menu_login.UnloggedinCmdSet"
-    CONNECTION_SCREEN_MODULE = "contrib.base_systems.menu_login.connection_screens"
+    CONNECTION_SCREEN_MODULE = "evennia.contrib.base_systems.menu_login.connection_screens"
 
 Reload the server and reconnect to see the changes.
 


### PR DESCRIPTION
Fixes the  CONNECTION_SCREEN_MODULE missing the evennia. before contrib.

#### Brief overview of PR changes/additions

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
